### PR TITLE
feat(plugin-tech-radar): export stateless ui component

### DIFF
--- a/workspaces/tech-radar/plugins/tech-radar/README.md
+++ b/workspaces/tech-radar/plugins/tech-radar/README.md
@@ -283,6 +283,19 @@ export const app = createApp({
 });
 ```
 
+#### Option C: Opt-out of statefullness and manage state independently
+
+In situations where you need to integrate a radar and manage state independently of Backstage, use the stateless UI component:
+
+```tsx
+import { StatelessRadar } from "@backstage-community/plugin-tech-radar";
+// load hardcoded data - or substitute with however you manage data state in your application
+import { data as techData } from "./data";
+
+// ...
+<StatelessRadar width={1500} height={800} {...techData} />
+```
+
 ### How do I write tests?
 
 You can use the `svgProps` option to pass custom React props to the `<svg>` element we create for the Tech Radar. This complements well with the `data-testid` attribute and the `@testing-library/react` library we use in Backstage.

--- a/workspaces/tech-radar/plugins/tech-radar/src/components/Radar/index.ts
+++ b/workspaces/tech-radar/plugins/tech-radar/src/components/Radar/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { default } from './Radar';
+export type { Props as RadarProps } from './Radar';

--- a/workspaces/tech-radar/plugins/tech-radar/src/components/index.ts
+++ b/workspaces/tech-radar/plugins/tech-radar/src/components/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+export { default as StatelessRadar } from './Radar';
+export type { StatelessRadarProps } from './Radar';
 export { RadarComponent as TechRadarComponent } from './RadarComponent';
 export type { TechRadarComponentProps } from './RadarComponent';
 export * from './RadarPage';


### PR DESCRIPTION
Allow upstream consumers to manage state independent of Backstage by exporting a stateless ui component of the tech radar.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
